### PR TITLE
Set bills date to last day of the month

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ function generateBills(invoices) {
   return invoices.map(item => {
     const amount = item.montant
     const amountStr = `${amount.toFixed(2)}${currency}`
-    const date = moment.utc(item.date, 'YYYY-MM-DD')
+    const date = moment.utc(item.date, 'YYYY-MM-DD').endOf('month')
     const dateStr = date.format('YYYY-MM-DD')
     const fileurl = `${baseUrl}${item.url}`
     const filename = `${dateStr}_${service}_${amountStr}_${item.numero}.pdf`

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ function generateBills(invoices) {
       filename: filename,
       metadata: {
         importDate: new Date(),
-        version: 1
+        version: 2
       }
     }
   })


### PR DESCRIPTION
This PR aims at fixing issue #12.

Retrieved date metadata from Tag&Pass API follows the format `YYYY-MM-01`, i.e. the day of the bill is always set to the first day of the month, even though the bill is emitted on the last day of the month (as seen on within the PDF files).
This is problematic when trying to match with bank statements, as the matching window is `[-15;+29]` days relative from the operation.

The connector now manually sets bills date to the last day of the month.
Also, bills metadata version is incremented to `2`.