### PR TITLE
Do not set filename date to end of month

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,14 +90,14 @@ function generateBills(invoices) {
   return invoices.map(item => {
     const amount = item.montant
     const amountStr = `${amount.toFixed(2)}${currency}`
-    const date = moment.utc(item.date, 'YYYY-MM-DD').endOf('month')
+    const date = moment.utc(item.date, 'YYYY-MM-DD')
     const dateStr = date.format('YYYY-MM-DD')
     const fileurl = `${baseUrl}${item.url}`
     const filename = `${dateStr}_${service}_${amountStr}_${item.numero}.pdf`
 
     return {
       vendor: vendor,
-      date: date.toDate(),
+      date: date.endOf('month').toDate(),
       amount: amount,
       currency: currency,
       fileurl: fileurl,


### PR DESCRIPTION
Following PR #17 for issue #12, only set `date` field to end of the month and leave the `filename` field to the original date (currently, first day of the month).